### PR TITLE
fix non determinism apphash crashes caused by sorting by id_election instead of id

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -342,7 +342,7 @@ impl VoteChainRunner {
                     tracing::info!("election: {id_election} sighash: {sighash}");
 
                     let hashes = sqlx::query(
-                        "SELECT t1.hash, t1.election
+                        "SELECT t1.hash
                         FROM cmx_roots t1
                         JOIN (
                             SELECT election, MAX(height) AS max_height
@@ -350,7 +350,8 @@ impl VoteChainRunner {
                             GROUP BY election
                         ) t2
                         ON t1.election = t2.election AND t1.height = t2.max_height
-                        ORDER BY t1.election"
+                        JOIN elections e ON t1.election = e.id_election
+                        ORDER BY e.id"
                     )
                     .map(|r: SqliteRow| {
                         let hash: Vec<u8> = r.get(0);


### PR DESCRIPTION
The Problem:
The AppHash query was ordering by `t1.election` (the auto-incrementing `id_election` INTEGER), which depends on the non-deterministic filesystem order from `read_dir()` during startup. This caused different validators to compute different AppHash values, breaking consensus.

The Fix:
Changed the SQL query in the `Command::FinalizeBallot` handler (lines 341-352):

- Added `JOIN elections e ON t1.election = e.id_election` to access the deterministic text election ID
- Changed `ORDER BY t1.election` to `ORDER BY e.id`
- Removed unused `t1.election` from SELECT clause (only `t1.hash` is needed)

The query now orders by `e.id` (the TEXT election identifier from JSON files), which is identical across all validators regardless of filesystem ordering.